### PR TITLE
Checked tasks on queries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ croncat-sdk-manager = "1.0.3"
 croncat-integration-utils = "1.1.0"
 # TODO: avoid using contract dep
 croncat-factory = { version = "1.0.3", features = ["library"] }
+croncat-manager = { version = "1.0.3", features = ["library"] }
 
 [dev-dependencies]
 app = { path = ".", features = ["interface"] }

--- a/src/api.rs
+++ b/src/api.rs
@@ -124,12 +124,14 @@ impl<'a, T: CronCatInterface> CronCat<'a, T> {
         &self,
         start_after: Option<(impl Into<String>, impl Into<String>)>,
         limit: Option<u32>,
+        checked: Option<bool>,
     ) -> AbstractSdkResult<Vec<(Addr, String)>> {
         self.base.apps(self.deps).query(
             self.module_id,
             AppQueryMsg::ActiveTasks {
                 start_after: start_after.map(|(addr, tag)| (addr.into(), tag.into())),
                 limit,
+                checked,
             },
         )
     }
@@ -140,6 +142,7 @@ impl<'a, T: CronCatInterface> CronCat<'a, T> {
         creator_addr: String,
         start_after: Option<impl Into<String>>,
         limit: Option<u32>,
+        checked: Option<bool>,
     ) -> AbstractSdkResult<Vec<String>> {
         self.base.apps(self.deps).query(
             self.module_id,
@@ -147,6 +150,7 @@ impl<'a, T: CronCatInterface> CronCat<'a, T> {
                 creator_addr,
                 start_after: start_after.map(Into::into),
                 limit,
+                checked,
             },
         )
     }

--- a/src/api.rs
+++ b/src/api.rs
@@ -86,6 +86,12 @@ impl<'a, T: CronCatInterface> CronCat<'a, T> {
             },
         )
     }
+
+    pub fn purge(&self, task_tags: Vec<String>) -> AbstractSdkResult<CosmosMsg> {
+        self.base
+            .apps(self.deps)
+            .request(self.module_id, AppExecuteMsg::Purge { task_tags })
+    }
 }
 
 impl<'a, T: CronCatInterface> CronCat<'a, T> {
@@ -268,6 +274,41 @@ mod test {
         });
 
         let actual = cron_cat.remove_task(task_tag);
+
+        assert_that!(actual).is_ok();
+
+        let actual = match actual.unwrap() {
+            CosmosMsg::Wasm(msg) => msg,
+            _ => panic!("expected wasm msg"),
+        };
+        let expected = wasm_execute(
+            abstract_testing::prelude::TEST_MODULE_ADDRESS,
+            &expected,
+            vec![],
+        )
+        .unwrap();
+
+        assert_that!(actual).is_equal_to(expected);
+    }
+
+    #[test]
+    fn purge_msg() {
+        let mut deps = mock_dependencies();
+        deps.querier = abstract_testing::mock_querier();
+        let stub = MockModule::new();
+        let mut cron_cat = stub.cron_cat(deps.as_ref());
+        cron_cat.module_id = TEST_MODULE_ID;
+
+        let task_tag1 = TEST_TASK_HASH.to_owned();
+        let task_tag2 = TEST_TASK_HASH.chars().rev().collect();
+
+        let task_tags = vec![task_tag1, task_tag2];
+
+        let expected = ExecuteMsg::from(AppExecuteMsg::Purge {
+            task_tags: task_tags.clone(),
+        });
+
+        let actual = cron_cat.purge(task_tags);
 
         assert_that!(actual).is_ok();
 

--- a/src/handlers/query.rs
+++ b/src/handlers/query.rs
@@ -176,7 +176,7 @@ fn query_active_tasks_by_creator(
             let factory_addr = factory_addr(&deps.querier, &app.ans_host(deps)?)?;
             let mut manager_addrs = HashMap::new();
             let mut removed_tasks = Vec::new();
-            
+
             // filter tasks that doesn't exist on croncat contract anymore
             let tasks_res: StdResult<Vec<String>> = iter
                 .filter(|res| {

--- a/src/handlers/query.rs
+++ b/src/handlers/query.rs
@@ -25,11 +25,10 @@ fn check_if_task_exists(
             Ok(addr) => addr,
             Err(_) => return false,
         };
-    match croncat_manager::state::TASKS_BALANCES.query(querier, manager_addr, task_hash.as_bytes())
-    {
-        Ok(Some(_)) => true,
-        _ => false,
-    }
+    matches!(
+        croncat_manager::state::TASKS_BALANCES.query(querier, manager_addr, task_hash.as_bytes()),
+        Ok(Some(_))
+    )
 }
 
 pub fn query_handler(

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -27,7 +27,6 @@ pub enum AppExecuteMsg {
         task_tag: String,
     },
     RefillTask {
-        /// check
         task_tag: String,
         assets: AssetListUnchecked,
     },

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -42,7 +42,7 @@ pub enum AppQueryMsg {
     #[returns(ConfigResponse)]
     Config {},
     /// Get active tasks
-    #[returns(Vec<(Addr, String)>)]
+    #[returns(ActiveTasksResponse)]
     ActiveTasks {
         #[cfg_attr(
             not(feature = "interface"),
@@ -62,7 +62,7 @@ pub enum AppQueryMsg {
         checked: Option<bool>,
     },
     /// Get active tasks by creator
-    #[returns(Vec<String>)]
+    #[returns(ActiveTasksByCreatorResponse)]
     ActiveTasksByCreator {
         #[cfg_attr(not(feature = "interface"), doc = "The addr of creator of tasks")]
         creator_addr: String,
@@ -108,4 +108,26 @@ pub enum Cw20HookMsg {
 #[cosmwasm_schema::cw_serde]
 pub struct ConfigResponse {
     pub config: Config,
+}
+
+#[cosmwasm_schema::cw_serde]
+pub enum ActiveTasksResponse {
+    Unchecked {
+        tasks: Vec<(Addr, String)>,
+    },
+    Checked {
+        scheduled_tasks: Vec<(Addr, String)>,
+        removed_tasks: Vec<(Addr, String)>,
+    },
+}
+
+#[cosmwasm_schema::cw_serde]
+pub enum ActiveTasksByCreatorResponse {
+    Unchecked {
+        tasks: Vec<String>,
+    },
+    Checked {
+        scheduled_tasks: Vec<String>,
+        removed_tasks: Vec<String>,
+    },
 }

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -27,6 +27,7 @@ pub enum AppExecuteMsg {
         task_tag: String,
     },
     RefillTask {
+        /// check
         task_tag: String,
         assets: AssetListUnchecked,
     },
@@ -37,24 +38,58 @@ pub enum AppExecuteMsg {
 #[cfg_attr(feature = "interface", impl_into(QueryMsg))]
 #[derive(QueryResponses)]
 pub enum AppQueryMsg {
+    /// Get config
     #[returns(ConfigResponse)]
     Config {},
+    /// Get active tasks
     #[returns(Vec<(Addr, String)>)]
     ActiveTasks {
+        #[cfg_attr(
+            not(feature = "interface"),
+            doc = "The addr and task tag to start listing after."
+        )]
         start_after: Option<(String, String)>,
+        #[cfg_attr(
+            not(feature = "interface"),
+            doc = "Maximum number of tasks to return. Default limit is 50, if not set"
+        )]
         limit: Option<u32>,
+        #[cfg_attr(
+            not(feature = "interface"),
+            doc = "On true check if this task exist on croncat contract and filter if it doesn't."
+        )]
+        #[cfg_attr(not(feature = "interface"), doc = "Defaults to false")]
+        checked: Option<bool>,
     },
+    /// Get active tasks by creator
     #[returns(Vec<String>)]
     ActiveTasksByCreator {
+        #[cfg_attr(not(feature = "interface"), doc = "The addr of creator of tasks")]
         creator_addr: String,
+        #[cfg_attr(
+            not(feature = "interface"),
+            doc = "The task tag to start listing after."
+        )]
         start_after: Option<String>,
+        #[cfg_attr(
+            not(feature = "interface"),
+            doc = "Maximum number of tasks to return. Default limit is 50, if not set"
+        )]
         limit: Option<u32>,
+        #[cfg_attr(
+            not(feature = "interface"),
+            doc = "On true check if this task exist on croncat contract and filter if it doesn't."
+        )]
+        #[cfg_attr(not(feature = "interface"), doc = "Defaults to false")]
+        checked: Option<bool>,
     },
+    /// Get task info
     #[returns(croncat_sdk_tasks::types::TaskResponse)]
     TaskInfo {
         creator_addr: String,
         task_tag: String,
     },
+    /// Get task balance
     #[returns(croncat_sdk_manager::types::TaskBalanceResponse)]
     TaskBalance {
         creator_addr: String,

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -30,6 +30,9 @@ pub enum AppExecuteMsg {
         task_tag: String,
         assets: AssetListUnchecked,
     },
+    Purge {
+        task_tags: Vec<String>,
+    },
 }
 
 #[cosmwasm_schema::cw_serde]

--- a/tests/common/contracts.rs
+++ b/tests/common/contracts.rs
@@ -1,4 +1,5 @@
-use cosmwasm_std::Empty;
+use app::msg::{ActiveTasksByCreatorResponse, ActiveTasksResponse};
+use cosmwasm_std::{Addr, Empty};
 use cw_multi_test::{Contract, ContractWrapper};
 
 pub(crate) use croncat_integration_testing::contracts::{
@@ -13,4 +14,53 @@ pub(crate) fn cw20_contract() -> Box<dyn Contract<Empty>> {
         cw20_base::contract::query,
     );
     Box::new(contract)
+}
+
+pub(crate) trait TasksResponseCaster {
+    type Item;
+
+    fn unchecked(self) -> Vec<Self::Item>;
+    fn checked(self) -> (Vec<Self::Item>, Vec<Self::Item>);
+}
+
+impl TasksResponseCaster for ActiveTasksResponse {
+    type Item = (Addr, String);
+
+    fn unchecked(self) -> Vec<Self::Item> {
+        match self {
+            ActiveTasksResponse::Unchecked { tasks } => tasks,
+            _ => panic!(),
+        }
+    }
+
+    fn checked(self) -> (Vec<Self::Item>, Vec<Self::Item>) {
+        match self {
+            ActiveTasksResponse::Checked {
+                scheduled_tasks,
+                removed_tasks,
+            } => (scheduled_tasks, removed_tasks),
+            _ => panic!(),
+        }
+    }
+}
+
+impl TasksResponseCaster for ActiveTasksByCreatorResponse {
+    type Item = String;
+
+    fn unchecked(self) -> Vec<Self::Item> {
+        match self {
+            ActiveTasksByCreatorResponse::Unchecked { tasks } => tasks,
+            _ => panic!(),
+        }
+    }
+
+    fn checked(self) -> (Vec<Self::Item>, Vec<Self::Item>) {
+        match self {
+            ActiveTasksByCreatorResponse::Checked {
+                scheduled_tasks,
+                removed_tasks,
+            } => (scheduled_tasks, removed_tasks),
+            _ => panic!(),
+        }
+    }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -895,7 +895,7 @@ fn remove_task() -> anyhow::Result<()> {
         active_tasks_checked.pop().unwrap().1,
         active_tasks.pop().unwrap().1,
     );
-    
+
     let proxy_cw20_balance1: cw20::BalanceResponse = mock.query(
         &Cw20QueryMsg::Balance {
             address: account.proxy.addr_str()?,


### PR DESCRIPTION
User can filter output of `active_tasks` and `active_tasks_by_creator` to see only tasks that still running :rocket: 

I know it looks a bit ugly